### PR TITLE
`uname -a` on WSL includes "Microsoft", not "Windows"

### DIFF
--- a/runtime/autoload/provider/clipboard.vim
+++ b/runtime/autoload/provider/clipboard.vim
@@ -8,7 +8,7 @@ let s:paste = {}
 " ownership of the selection, so we know how long the cache is valid.
 let s:selection = { 'owner': 0, 'data': [] }
 
-let s:win_wsl = (system(['uname', '-a']) =~? 'Windows')
+let s:win_wsl = (system(['uname', '-a']) =~? 'Microsoft')
 
 function! s:selection.on_exit(jobid, data, event) abort
   " At this point this nvim instance might already have launched


### PR DESCRIPTION
Full uname for reference:
Linux ZBook 4.4.0-43-Microsoft #1-Microsoft Wed Dec 31 14:42:53 PST 2014
x86_64 x86_64 x86_64 GNU/Linux